### PR TITLE
README.md: All installation steps in one code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone https://github.com/core-code/CoreLib.git
 git clone https://github.com/core-code/VirusCheckHBC.git
 
 # Compile and install (will be in /usr/local/bin):
-cd VirusCheckHBC
+cd VirusCheckHBC || exit 1
 xcodebuild install DSTROOT=/
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
 # VirusCheckHBC
 CLI tool to check all of 'Homebrew Cask' using VirusTotal
 
-Usage:
+Installation:
 
-Make sure you checkout the 'CoreLib' next (!) to the VirusCheckHBC folder:
+```shell
+# Clone `CoreLib` and this directory next (!) to each other:
+cd "$(mktemp -d)" || exit 1 # Temporary directory
 
-`git clone https://github.com/core-code/CoreLib.git`
+git clone https://github.com/core-code/CoreLib.git
+git clone https://github.com/core-code/VirusCheckHBC.git
 
-`git clone https://github.com/core-code/VirusCheckHBC.git`
+# Compile and install (will be in /usr/local/bin):
+cd VirusCheckHBC
+xcodebuild install DSTROOT=/
+```
 
+Run it by speciying your APIKEY:
 
-Now compile and install it: 
-
-`cd VirusCheckHBC/`
-
-`xcodebuild install DSTROOT=/`
-
-run it by speciying your APIKEY:
-
-`VIRUSTOTAL_APIKEY=bla VirusCheckHBC`
+```shell
+VIRUSTOTAL_APIKEY=bla VirusCheckHBC
+```


### PR DESCRIPTION
Proposal to stick all installation steps in one code block, so users only need to copy and paste once.

Also made it change to a temporary directory, so it gets auto-cleaned up with other things.

`|| exit 1` should never trigger, but it’s a failsafe recommended so commands don’t try to run out of place.